### PR TITLE
Add buttons for toggling needs

### DIFF
--- a/app/assets/stylesheets/application.scss
+++ b/app/assets/stylesheets/application.scss
@@ -1,1 +1,2 @@
 @import 'bootstrap';
+@import 'needs';

--- a/app/assets/stylesheets/needs.scss
+++ b/app/assets/stylesheets/needs.scss
@@ -1,0 +1,5 @@
+.needs-list {
+  form {
+    display: inline-block;
+  }
+}

--- a/app/controllers/admin/needs_controller.rb
+++ b/app/controllers/admin/needs_controller.rb
@@ -1,15 +1,13 @@
 class Admin::NeedsController < ApplicationController
-  def new
-    @organization = Organization.find(params[:organization_id])
-    @need = @organization.needs.new
+  def edit
+    @need = Need.find(params[:id])
   end
 
-  def create
-    @organization = Organization.find(params[:organization_id])
-    @need = @organization.needs.new(need_params)
+  def update
+    @need = Need.find(params[:id])
 
-    if @need.save
-      redirect_to [:admin, @organization]
+    if @need.update(need_params)
+      redirect_to [:admin, @need.organization]
     else
       render :new
     end
@@ -34,6 +32,6 @@ class Admin::NeedsController < ApplicationController
   private
 
   def need_params
-    params.require(:need).permit(:item, :comment)
+    params.require(:need).permit(:comment)
   end
 end

--- a/app/controllers/admin/needs_controller.rb
+++ b/app/controllers/admin/needs_controller.rb
@@ -15,6 +15,22 @@ class Admin::NeedsController < ApplicationController
     end
   end
 
+  def enable
+    @need = Need.find(params[:need_id])
+
+    @need.update!(enabled: true)
+
+    render 'replace_button'
+  end
+
+  def disable
+    @need = Need.find(params[:need_id])
+
+    @need.update!(enabled: false)
+
+    render 'replace_button'
+  end
+
   private
 
   def need_params

--- a/app/controllers/admin/organizations_controller.rb
+++ b/app/controllers/admin/organizations_controller.rb
@@ -2,6 +2,8 @@ module Admin
   class OrganizationsController < ApplicationController
     def show
       @organization = Organization.find(params[:id])
+
+      @needs = @organization.needs.order(:item)
     end
   end
 end

--- a/app/views/admin/needs/_need.html.erb
+++ b/app/views/admin/needs/_need.html.erb
@@ -1,0 +1,10 @@
+<% if need.enabled? %>
+  <% url = admin_need_disable_path(need) %>
+  <% style = 'success' %>
+<% else %>
+  <% url = admin_need_enable_path(need) %>
+  <% style = 'secondary' %>
+<% end %>
+<%= button_to need.item, url, method: :patch, remote: true,
+  form: { id: "need-btn-#{need.id}" },
+  class: "btn btn-#{style} mt-2" %>

--- a/app/views/admin/needs/_need.html.erb
+++ b/app/views/admin/needs/_need.html.erb
@@ -1,10 +1,17 @@
-<% if need.enabled? %>
-  <% url = admin_need_disable_path(need) %>
-  <% style = 'success' %>
-<% else %>
-  <% url = admin_need_enable_path(need) %>
-  <% style = 'secondary' %>
-<% end %>
-<%= button_to need.item, url, method: :patch, remote: true,
-  form: { id: "need-btn-#{need.id}" },
-  class: "btn btn-#{style} mt-2" %>
+<li id="need-btn-<%= need.id %>" >
+  <% if need.enabled? %>
+    <% url = admin_need_disable_path(need) %>
+    <% style = 'success' %>
+  <% else %>
+    <% url = admin_need_enable_path(need) %>
+    <% style = 'secondary' %>
+  <% end %>
+
+  <%= button_to need.item, url, method: :patch, remote: true,
+    class: "btn btn-inline btn-#{style} mt-2" %>
+
+  <% if need.enabled? %>
+    <%= link_to 'Add/edit comment',
+      edit_admin_need_path(need) %>
+  <% end %>
+</li>

--- a/app/views/admin/needs/edit.html.erb
+++ b/app/views/admin/needs/edit.html.erb
@@ -1,7 +1,7 @@
 <%= form_for [:admin, @organization, @need] do |f| %>
   <div class="form-group">
     <%= f.label :item %>
-    <%= f.text_field :item, class: 'form-control' %>
+    <%= f.text_field :item, class: 'form-control', disabled: true %>
   </div>
 
   <div class="form-group">

--- a/app/views/admin/needs/replace_button.js.erb
+++ b/app/views/admin/needs/replace_button.js.erb
@@ -1,0 +1,3 @@
+var btn_el = document.getElementById('need-btn-<%= @need.id %>');
+
+btn_el.outerHTML = '<%= j(render(@need)) %>';

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -5,12 +5,8 @@
   target: '_blank'
 %>
 
-<ul class="list-unstyled">
+<ul class="needs-list list-unstyled">
   <% @needs.each do |need| %>
-    <li>
-      <%= render need %>
-    </li>
+    <%= render need %>
   <% end %>
 </ul>
-
-<%= link_to 'Add item request', new_admin_organization_need_path(@organization) %>

--- a/app/views/admin/organizations/show.html.erb
+++ b/app/views/admin/organizations/show.html.erb
@@ -5,10 +5,10 @@
   target: '_blank'
 %>
 
-<ul>
-  <% @organization.needs.each do |need| %>
+<ul class="list-unstyled">
+  <% @needs.each do |need| %>
     <li>
-      <%= need.item %>
+      <%= render need %>
     </li>
   <% end %>
 </ul>

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -13,5 +13,10 @@ Rails.application.routes.draw do
     resources :organizations, only: [:show] do
       resources :needs, only: [:new, :create]
     end
+
+    resources :needs, only: [] do
+      patch :enable
+      patch :disable
+    end
   end
 end

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -10,11 +10,9 @@ Rails.application.routes.draw do
   resources :users, only: [:new, :create, :index]
 
   namespace :admin do
-    resources :organizations, only: [:show] do
-      resources :needs, only: [:new, :create]
-    end
+    resources :organizations, only: [:show]
 
-    resources :needs, only: [] do
+    resources :needs, only: [:edit, :update] do
       patch :enable
       patch :disable
     end

--- a/db/migrate/20180504001147_add_enabled_to_needs.rb
+++ b/db/migrate/20180504001147_add_enabled_to_needs.rb
@@ -1,0 +1,5 @@
+class AddEnabledToNeeds < ActiveRecord::Migration[5.2]
+  def change
+    add_column :needs, :enabled, :bool, null: false, default: true
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2018_04_30_014431) do
+ActiveRecord::Schema.define(version: 2018_05_04_001147) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
@@ -21,6 +21,7 @@ ActiveRecord::Schema.define(version: 2018_04_30_014431) do
     t.string "comment"
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
+    t.boolean "enabled", default: true, null: false
     t.index ["organization_id"], name: "index_needs_on_organization_id"
   end
 

--- a/test/system/admin/add_needs_test.rb
+++ b/test/system/admin/add_needs_test.rb
@@ -14,7 +14,18 @@ module Admin
       click_button 'Submit'
 
       assert_equal admin_organization_path(organization), current_path
-      assert_text 'Socks'
+      assert_button 'Socks'
+    end
+
+    test 'disable a need' do
+      organization = create(:organization)
+      socks = create(:need, item: 'Socks', organization: organization)
+      visit admin_organization_path(organization)
+
+      click_button 'Socks'
+
+      assert_button 'Socks', class: 'btn-secondary'
+      assert_not socks.reload.enabled?
     end
   end
 end

--- a/test/system/admin/add_needs_test.rb
+++ b/test/system/admin/add_needs_test.rb
@@ -2,19 +2,19 @@ require "application_system_test_case"
 
 module Admin
   class AddNeedsTest < ApplicationSystemTestCase
-    test 'add an item that the organization needs' do
+    test 'add comment to a need' do
       organization = create(:organization)
+      need = create(:need, organization: organization)
       visit admin_organization_path(organization)
 
-      click_link 'Add item request'
+      click_link 'Add/edit comment'
 
-      fill_in 'Item', with: 'Socks'
       fill_in 'Comment', with: 'Must be good quality'
 
       click_button 'Submit'
 
       assert_equal admin_organization_path(organization), current_path
-      assert_button 'Socks'
+      assert_equal 'Must be good quality', need.reload.comment
     end
 
     test 'disable a need' do


### PR DESCRIPTION
Display previous list on organization page as toggleable buttons. Remove previous needs creation page with an comment edit form.