### PR TITLE
Override connection URL to use PostGIS

### DIFF
--- a/config/database.yml
+++ b/config/database.yml
@@ -16,4 +16,4 @@ test:
 
 production:
   <<: *default
-  database: my-brothers-keeper_production
+  url: <%= ENV.fetch('DATABASE_URL', '').sub(/^postgres/, 'postgis') %>


### PR DESCRIPTION
Apparently the database url overrides the adapter, we need to find and replace on it to enable PostGIS.


Hopefully this will fix our Heroku issues :crossed_fingers: 