### PR TITLE
Use DOMAIN instead of HOST for default URL config

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -16,6 +16,6 @@ module BrothersKeeper
     # -- all .rb files in that directory are automatically loaded after loading
     # the framework and any gems in your application.
 
-    config.action_mailer.default_url_options = { host: ENV.fetch('HOST', 'localhost:3000') }
+    config.action_mailer.default_url_options = { host: ENV.fetch('DOMAIN', 'localhost:3000') }
   end
 end


### PR DESCRIPTION
Puma tries to bind to whatever we set the HOST variable to, so use DOMAIN for our email configuration instead.