### PR TITLE
Fix failing email test

### DIFF
--- a/config/environments/test.rb
+++ b/config/environments/test.rb
@@ -38,6 +38,9 @@ Rails.application.configure do
   # ActionMailer::Base.deliveries array.
   config.action_mailer.delivery_method = :test
 
+  # Tell ActiveJob to perform tasks inline for testing
+  config.active_job.queue_adapter = :inline
+
   # Print deprecation notices to the stderr.
   config.active_support.deprecation = :stderr
 


### PR DESCRIPTION
Configuring active job with inline queue adapter in the test environment causes it to run asynchronous tasks synchronously instead. It seems to work consistently as I re-ran the tests several times.